### PR TITLE
Don't use hkps to get key

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -27,12 +27,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: ["alpine-pypy-builder", "alpine-pypy-builder-bootstrap", "alpine-pypy-2_7", "alpine-pypy-3_9", "alpine-pypy-3_10"] # "python-2_7"
+        target: ["python-2_7", "alpine-pypy-builder", "alpine-pypy-builder-bootstrap", "alpine-pypy-2_7", "alpine-pypy-3_9", "alpine-pypy-3_10"]
         runner: ["ubuntu-latest", "self-hosted"]
         # Don't know a better way to only run python-2_7 on self-hosted
         exclude:
-          # - target: "python-2_7"
-          #   runner: "ubuntu-latest"
+          - target: "python-2_7"
+            runner: "ubuntu-latest"
           - target: "alpine-pypy-builder"
             runner: "self-hosted"
           - target: "alpine-pypy-builder-bootstrap"

--- a/python-2.7/Dockerfile
+++ b/python-2.7/Dockerfile
@@ -19,7 +19,7 @@ RUN /bin/sh -c set -ex 	&& apk add --no-cache --virtual .fetch-deps \
     wget -O python.tar.xz "https://www.python.org/ftp/python/${PYTHON_VERSION%%[a-z]*}/Python-$PYTHON_VERSION.tar.xz" && \
     wget -O python.tar.xz.asc "https://pypy.cyberjake.xyz/python/python-${PYTHON_VERSION%%[a-z]*}/python-$PYTHON_VERSION.tar.xz.sig" && \
     export GNUPGHOME="$(mktemp -d)" && \
-    gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys "$GPG_KEY" && \
+    gpg --batch --keyserver hkp://keys.openpgp.org:80 --recv-keys "$GPG_KEY" && \
     gpg --batch --verify python.tar.xz.asc python.tar.xz && \
     { command -v gpgconf > /dev/null && gpgconf --kill all || :; }&& \
     rm -rf "$GNUPGHOME" python.tar.xz.asc && \


### PR DESCRIPTION
Fixes issue with building python 2.7 container by not using hkps to download the key.