### PR TITLE
Change to PyPy 7.3.15 as default in export image

### DIFF
--- a/export/Dockerfile
+++ b/export/Dockerfile
@@ -10,7 +10,7 @@ ENV GPG_KEY=44FE09DEE9E9EC21EF903F06CA614AB6BD73BB06
 
 # Download the source
 ARG PYPY_BASE=3.10
-ARG PYPY_VERSION=7.3.14
+ARG PYPY_VERSION=7.3.15
 
 RUN set -ex; \
     apk add --no-cache --virtual .fetch-deps \


### PR DESCRIPTION
This doesn't have any effect on current version as that is override by the variable in the docker-bake file.